### PR TITLE
Now in-process embedding models can embed texts longer than 510 tokens

### DIFF
--- a/langchain4j-embeddings-all-minilm-l6-v2-q/src/test/java/dev/langchain4j/model/embedding/ALL_MINILM_L6_V2_Q_EmbeddingModelTest.java
+++ b/langchain4j-embeddings-all-minilm-l6-v2-q/src/test/java/dev/langchain4j/model/embedding/ALL_MINILM_L6_V2_Q_EmbeddingModelTest.java
@@ -66,10 +66,10 @@ class ALL_MINILM_L6_V2_Q_EmbeddingModelTest {
         Embedding embedding510 = model.embed(repeat(oneToken, 510));
         assertThat(embedding510.vector()).hasSize(384);
 
-        Embedding embedding520 = model.embed(repeat(oneToken, 520));
-        assertThat(embedding520.vector()).hasSize(384);
+        Embedding embedding511 = model.embed(repeat(oneToken, 511));
+        assertThat(embedding511.vector()).hasSize(384);
 
-        assertThat(Similarity.cosine(embedding510.vector(), embedding520.vector())).isGreaterThan(0.99);
+        assertThat(Similarity.cosine(embedding510.vector(), embedding511.vector())).isGreaterThan(0.99);
     }
 
     @Test

--- a/langchain4j-embeddings-all-minilm-l6-v2/src/test/java/dev/langchain4j/model/embedding/ALL_MINILM_L6_V2_EmbeddingModelTest.java
+++ b/langchain4j-embeddings-all-minilm-l6-v2/src/test/java/dev/langchain4j/model/embedding/ALL_MINILM_L6_V2_EmbeddingModelTest.java
@@ -66,10 +66,10 @@ class ALL_MINILM_L6_V2_EmbeddingModelTest {
         Embedding embedding510 = model.embed(repeat(oneToken, 510));
         assertThat(embedding510.vector()).hasSize(384);
 
-        Embedding embedding520 = model.embed(repeat(oneToken, 520));
-        assertThat(embedding520.vector()).hasSize(384);
+        Embedding embedding511 = model.embed(repeat(oneToken, 511));
+        assertThat(embedding511.vector()).hasSize(384);
 
-        assertThat(Similarity.cosine(embedding510.vector(), embedding520.vector())).isGreaterThan(0.99);
+        assertThat(Similarity.cosine(embedding510.vector(), embedding511.vector())).isGreaterThan(0.99);
     }
 
     @Test

--- a/langchain4j-embeddings-all-minilm-l6-v2/src/test/java/dev/langchain4j/model/embedding/ALL_MINILM_L6_V2_EmbeddingModelTest.java
+++ b/langchain4j-embeddings-all-minilm-l6-v2/src/test/java/dev/langchain4j/model/embedding/ALL_MINILM_L6_V2_EmbeddingModelTest.java
@@ -2,12 +2,13 @@ package dev.langchain4j.model.embedding;
 
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.store.embedding.RelevanceScore;
+import dev.langchain4j.store.embedding.Similarity;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static dev.langchain4j.internal.Utils.repeat;
+import static dev.langchain4j.model.embedding.internal.VectorUtils.magnitudeOf;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.data.Percentage.withPercentage;
 
 class ALL_MINILM_L6_V2_EmbeddingModelTest {
@@ -56,14 +57,32 @@ class ALL_MINILM_L6_V2_EmbeddingModelTest {
 
     @Test
     @Disabled("Temporary disabling. This test should run only when this or used (e.g. langchain4j-embeddings) module(s) change")
-    void should_fail_to_embed_511_token_long_text() {
+    void should_embed_text_longer_than_510_tokens_by_splitting_and_averaging_embeddings_of_splits() {
 
         EmbeddingModel model = new ALL_MINILM_L6_V2_EmbeddingModel();
 
         String oneToken = "hello ";
 
-        assertThatThrownBy(() -> model.embed(repeat(oneToken, 511)))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Cannot embed text longer than 510 tokens. The following text is 511 tokens long: hello hello");
+        Embedding embedding510 = model.embed(repeat(oneToken, 510));
+        assertThat(embedding510.vector()).hasSize(384);
+
+        Embedding embedding520 = model.embed(repeat(oneToken, 520));
+        assertThat(embedding520.vector()).hasSize(384);
+
+        assertThat(Similarity.cosine(embedding510.vector(), embedding520.vector())).isGreaterThan(0.99);
+    }
+
+    @Test
+    @Disabled("Temporary disabling. This test should run only when this or used (e.g. langchain4j-embeddings) module(s) change")
+    void should_produce_normalized_vectors() {
+
+        EmbeddingModel model = new ALL_MINILM_L6_V2_EmbeddingModel();
+
+        String oneToken = "hello ";
+
+        assertThat(magnitudeOf(model.embed(oneToken)))
+                .isCloseTo(1, withPercentage(0.01));
+        assertThat(magnitudeOf(model.embed(repeat(oneToken, 999))))
+                .isCloseTo(1, withPercentage(0.01));
     }
 }

--- a/langchain4j-embeddings-bge-small-en-q/src/test/java/dev/langchain4j/model/embedding/BGE_SMALL_EN_Q_EmbeddingModelTest.java
+++ b/langchain4j-embeddings-bge-small-en-q/src/test/java/dev/langchain4j/model/embedding/BGE_SMALL_EN_Q_EmbeddingModelTest.java
@@ -52,10 +52,10 @@ class BGE_SMALL_EN_Q_EmbeddingModelTest {
         Embedding embedding510 = model.embed(repeat(oneToken, 510));
         assertThat(embedding510.vector()).hasSize(384);
 
-        Embedding embedding520 = model.embed(repeat(oneToken, 520));
-        assertThat(embedding520.vector()).hasSize(384);
+        Embedding embedding511 = model.embed(repeat(oneToken, 511));
+        assertThat(embedding511.vector()).hasSize(384);
 
-        assertThat(Similarity.cosine(embedding510.vector(), embedding520.vector())).isGreaterThan(0.99);
+        assertThat(Similarity.cosine(embedding510.vector(), embedding511.vector())).isGreaterThan(0.99);
     }
 
     @Test

--- a/langchain4j-embeddings-bge-small-en-q/src/test/java/dev/langchain4j/model/embedding/BGE_SMALL_EN_Q_EmbeddingModelTest.java
+++ b/langchain4j-embeddings-bge-small-en-q/src/test/java/dev/langchain4j/model/embedding/BGE_SMALL_EN_Q_EmbeddingModelTest.java
@@ -2,12 +2,14 @@ package dev.langchain4j.model.embedding;
 
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.store.embedding.RelevanceScore;
+import dev.langchain4j.store.embedding.Similarity;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static dev.langchain4j.internal.Utils.repeat;
+import static dev.langchain4j.model.embedding.internal.VectorUtils.magnitudeOf;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.data.Percentage.withPercentage;
 
 class BGE_SMALL_EN_Q_EmbeddingModelTest {
 
@@ -41,14 +43,32 @@ class BGE_SMALL_EN_Q_EmbeddingModelTest {
 
     @Test
     @Disabled("Temporary disabling. This test should run only when this or used (e.g. langchain4j-embeddings) module(s) change")
-    void should_fail_to_embed_511_token_long_text() {
+    void should_embed_text_longer_than_510_tokens_by_splitting_and_averaging_embeddings_of_splits() {
 
         EmbeddingModel model = new BGE_SMALL_EN_Q_EmbeddingModel();
 
         String oneToken = "hello ";
 
-        assertThatThrownBy(() -> model.embed(repeat(oneToken, 511)))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Cannot embed text longer than 510 tokens. The following text is 511 tokens long: hello hello");
+        Embedding embedding510 = model.embed(repeat(oneToken, 510));
+        assertThat(embedding510.vector()).hasSize(384);
+
+        Embedding embedding520 = model.embed(repeat(oneToken, 520));
+        assertThat(embedding520.vector()).hasSize(384);
+
+        assertThat(Similarity.cosine(embedding510.vector(), embedding520.vector())).isGreaterThan(0.99);
+    }
+
+    @Test
+    @Disabled("Temporary disabling. This test should run only when this or used (e.g. langchain4j-embeddings) module(s) change")
+    void should_produce_normalized_vectors() {
+
+        EmbeddingModel model = new BGE_SMALL_EN_Q_EmbeddingModel();
+
+        String oneToken = "hello ";
+
+        assertThat(magnitudeOf(model.embed(oneToken)))
+                .isCloseTo(1, withPercentage(0.01));
+        assertThat(magnitudeOf(model.embed(repeat(oneToken, 999))))
+                .isCloseTo(1, withPercentage(0.01));
     }
 }

--- a/langchain4j-embeddings-bge-small-en/src/test/java/dev/langchain4j/model/embedding/BGE_SMALL_EN_EmbeddingModelTest.java
+++ b/langchain4j-embeddings-bge-small-en/src/test/java/dev/langchain4j/model/embedding/BGE_SMALL_EN_EmbeddingModelTest.java
@@ -2,12 +2,13 @@ package dev.langchain4j.model.embedding;
 
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.store.embedding.RelevanceScore;
+import dev.langchain4j.store.embedding.Similarity;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static dev.langchain4j.internal.Utils.repeat;
+import static dev.langchain4j.model.embedding.internal.VectorUtils.magnitudeOf;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.data.Percentage.withPercentage;
 
 class BGE_SMALL_EN_EmbeddingModelTest {
@@ -56,14 +57,32 @@ class BGE_SMALL_EN_EmbeddingModelTest {
 
     @Test
     @Disabled("Temporary disabling. This test should run only when this or used (e.g. langchain4j-embeddings) module(s) change")
-    void should_fail_to_embed_511_token_long_text() {
+    void should_embed_text_longer_than_510_tokens_by_splitting_and_averaging_embeddings_of_splits() {
 
         EmbeddingModel model = new BGE_SMALL_EN_EmbeddingModel();
 
         String oneToken = "hello ";
 
-        assertThatThrownBy(() -> model.embed(repeat(oneToken, 511)))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Cannot embed text longer than 510 tokens. The following text is 511 tokens long: hello hello");
+        Embedding embedding510 = model.embed(repeat(oneToken, 510));
+        assertThat(embedding510.vector()).hasSize(384);
+
+        Embedding embedding520 = model.embed(repeat(oneToken, 520));
+        assertThat(embedding520.vector()).hasSize(384);
+
+        assertThat(Similarity.cosine(embedding510.vector(), embedding520.vector())).isGreaterThan(0.99);
+    }
+
+    @Test
+    @Disabled("Temporary disabling. This test should run only when this or used (e.g. langchain4j-embeddings) module(s) change")
+    void should_produce_normalized_vectors() {
+
+        EmbeddingModel model = new BGE_SMALL_EN_EmbeddingModel();
+
+        String oneToken = "hello ";
+
+        assertThat(magnitudeOf(model.embed(oneToken)))
+                .isCloseTo(1, withPercentage(0.01));
+        assertThat(magnitudeOf(model.embed(repeat(oneToken, 999))))
+                .isCloseTo(1, withPercentage(0.01));
     }
 }

--- a/langchain4j-embeddings-bge-small-en/src/test/java/dev/langchain4j/model/embedding/BGE_SMALL_EN_EmbeddingModelTest.java
+++ b/langchain4j-embeddings-bge-small-en/src/test/java/dev/langchain4j/model/embedding/BGE_SMALL_EN_EmbeddingModelTest.java
@@ -66,10 +66,10 @@ class BGE_SMALL_EN_EmbeddingModelTest {
         Embedding embedding510 = model.embed(repeat(oneToken, 510));
         assertThat(embedding510.vector()).hasSize(384);
 
-        Embedding embedding520 = model.embed(repeat(oneToken, 520));
-        assertThat(embedding520.vector()).hasSize(384);
+        Embedding embedding511 = model.embed(repeat(oneToken, 511));
+        assertThat(embedding511.vector()).hasSize(384);
 
-        assertThat(Similarity.cosine(embedding510.vector(), embedding520.vector())).isGreaterThan(0.99);
+        assertThat(Similarity.cosine(embedding510.vector(), embedding511.vector())).isGreaterThan(0.99);
     }
 
     @Test

--- a/langchain4j-embeddings-bge-small-zh-q/src/test/java/dev/langchain4j/model/embedding/BGE_SMALL_ZH_Q_EmbeddingModelTest.java
+++ b/langchain4j-embeddings-bge-small-zh-q/src/test/java/dev/langchain4j/model/embedding/BGE_SMALL_ZH_Q_EmbeddingModelTest.java
@@ -52,10 +52,10 @@ class BGE_SMALL_ZH_Q_EmbeddingModelTest {
         Embedding embedding510 = model.embed(repeat(oneToken, 510));
         assertThat(embedding510.vector()).hasSize(512);
 
-        Embedding embedding520 = model.embed(repeat(oneToken, 520));
-        assertThat(embedding520.vector()).hasSize(512);
+        Embedding embedding511 = model.embed(repeat(oneToken, 511));
+        assertThat(embedding511.vector()).hasSize(512);
 
-        assertThat(Similarity.cosine(embedding510.vector(), embedding520.vector())).isGreaterThan(0.99);
+        assertThat(Similarity.cosine(embedding510.vector(), embedding511.vector())).isGreaterThan(0.99);
     }
 
     @Test

--- a/langchain4j-embeddings-bge-small-zh-q/src/test/java/dev/langchain4j/model/embedding/BGE_SMALL_ZH_Q_EmbeddingModelTest.java
+++ b/langchain4j-embeddings-bge-small-zh-q/src/test/java/dev/langchain4j/model/embedding/BGE_SMALL_ZH_Q_EmbeddingModelTest.java
@@ -2,12 +2,14 @@ package dev.langchain4j.model.embedding;
 
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.store.embedding.RelevanceScore;
+import dev.langchain4j.store.embedding.Similarity;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static dev.langchain4j.internal.Utils.repeat;
+import static dev.langchain4j.model.embedding.internal.VectorUtils.magnitudeOf;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.data.Percentage.withPercentage;
 
 class BGE_SMALL_ZH_Q_EmbeddingModelTest {
 
@@ -41,14 +43,32 @@ class BGE_SMALL_ZH_Q_EmbeddingModelTest {
 
     @Test
     @Disabled("Temporary disabling. This test should run only when this or used (e.g. langchain4j-embeddings) module(s) change")
-    void should_fail_to_embed_511_token_long_text() {
+    void should_embed_text_longer_than_510_tokens_by_splitting_and_averaging_embeddings_of_splits() {
 
         EmbeddingModel model = new BGE_SMALL_ZH_Q_EmbeddingModel();
 
         String oneToken = "书 ";
 
-        assertThatThrownBy(() -> model.embed(repeat(oneToken, 511)))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Cannot embed text longer than 510 tokens. The following text is 511 tokens long: 书 书");
+        Embedding embedding510 = model.embed(repeat(oneToken, 510));
+        assertThat(embedding510.vector()).hasSize(512);
+
+        Embedding embedding520 = model.embed(repeat(oneToken, 520));
+        assertThat(embedding520.vector()).hasSize(512);
+
+        assertThat(Similarity.cosine(embedding510.vector(), embedding520.vector())).isGreaterThan(0.99);
+    }
+
+    @Test
+    @Disabled("Temporary disabling. This test should run only when this or used (e.g. langchain4j-embeddings) module(s) change")
+    void should_produce_normalized_vectors() {
+
+        EmbeddingModel model = new BGE_SMALL_ZH_Q_EmbeddingModel();
+
+        String oneToken = "书 ";
+
+        assertThat(magnitudeOf(model.embed(oneToken)))
+                .isCloseTo(1, withPercentage(0.01));
+        assertThat(magnitudeOf(model.embed(repeat(oneToken, 999))))
+                .isCloseTo(1, withPercentage(0.01));
     }
 }

--- a/langchain4j-embeddings-bge-small-zh/src/test/java/dev/langchain4j/model/embedding/BGE_SMALL_ZH_EmbeddingModelTest.java
+++ b/langchain4j-embeddings-bge-small-zh/src/test/java/dev/langchain4j/model/embedding/BGE_SMALL_ZH_EmbeddingModelTest.java
@@ -2,12 +2,13 @@ package dev.langchain4j.model.embedding;
 
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.store.embedding.RelevanceScore;
+import dev.langchain4j.store.embedding.Similarity;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static dev.langchain4j.internal.Utils.repeat;
+import static dev.langchain4j.model.embedding.internal.VectorUtils.magnitudeOf;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.data.Percentage.withPercentage;
 
 class BGE_SMALL_ZH_EmbeddingModelTest {
@@ -56,14 +57,32 @@ class BGE_SMALL_ZH_EmbeddingModelTest {
 
     @Test
     @Disabled("Temporary disabling. This test should run only when this or used (e.g. langchain4j-embeddings) module(s) change")
-    void should_fail_to_embed_511_token_long_text() {
+    void should_embed_text_longer_than_510_tokens_by_splitting_and_averaging_embeddings_of_splits() {
 
         EmbeddingModel model = new BGE_SMALL_ZH_EmbeddingModel();
 
         String oneToken = "书 ";
 
-        assertThatThrownBy(() -> model.embed(repeat(oneToken, 511)))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Cannot embed text longer than 510 tokens. The following text is 511 tokens long: 书 书");
+        Embedding embedding510 = model.embed(repeat(oneToken, 510));
+        assertThat(embedding510.vector()).hasSize(512);
+
+        Embedding embedding520 = model.embed(repeat(oneToken, 520));
+        assertThat(embedding520.vector()).hasSize(512);
+
+        assertThat(Similarity.cosine(embedding510.vector(), embedding520.vector())).isGreaterThan(0.99);
+    }
+
+    @Test
+    @Disabled("Temporary disabling. This test should run only when this or used (e.g. langchain4j-embeddings) module(s) change")
+    void should_produce_normalized_vectors() {
+
+        EmbeddingModel model = new BGE_SMALL_ZH_EmbeddingModel();
+
+        String oneToken = "书 ";
+
+        assertThat(magnitudeOf(model.embed(oneToken)))
+                .isCloseTo(1, withPercentage(0.01));
+        assertThat(magnitudeOf(model.embed(repeat(oneToken, 999))))
+                .isCloseTo(1, withPercentage(0.01));
     }
 }

--- a/langchain4j-embeddings-bge-small-zh/src/test/java/dev/langchain4j/model/embedding/BGE_SMALL_ZH_EmbeddingModelTest.java
+++ b/langchain4j-embeddings-bge-small-zh/src/test/java/dev/langchain4j/model/embedding/BGE_SMALL_ZH_EmbeddingModelTest.java
@@ -66,10 +66,10 @@ class BGE_SMALL_ZH_EmbeddingModelTest {
         Embedding embedding510 = model.embed(repeat(oneToken, 510));
         assertThat(embedding510.vector()).hasSize(512);
 
-        Embedding embedding520 = model.embed(repeat(oneToken, 520));
-        assertThat(embedding520.vector()).hasSize(512);
+        Embedding embedding511 = model.embed(repeat(oneToken, 511));
+        assertThat(embedding511.vector()).hasSize(512);
 
-        assertThat(Similarity.cosine(embedding510.vector(), embedding520.vector())).isGreaterThan(0.99);
+        assertThat(Similarity.cosine(embedding510.vector(), embedding511.vector())).isGreaterThan(0.99);
     }
 
     @Test

--- a/langchain4j-embeddings-e5-small-v2-q/src/test/java/dev/langchain4j/model/embedding/E5_SMALL_V2_Q_EmbeddingModelTest.java
+++ b/langchain4j-embeddings-e5-small-v2-q/src/test/java/dev/langchain4j/model/embedding/E5_SMALL_V2_Q_EmbeddingModelTest.java
@@ -66,10 +66,10 @@ class E5_SMALL_V2_Q_EmbeddingModelTest {
         Embedding embedding510 = model.embed(repeat(oneToken, 510));
         assertThat(embedding510.vector()).hasSize(384);
 
-        Embedding embedding520 = model.embed(repeat(oneToken, 520));
-        assertThat(embedding520.vector()).hasSize(384);
+        Embedding embedding511 = model.embed(repeat(oneToken, 511));
+        assertThat(embedding511.vector()).hasSize(384);
 
-        assertThat(Similarity.cosine(embedding510.vector(), embedding520.vector())).isGreaterThan(0.99);
+        assertThat(Similarity.cosine(embedding510.vector(), embedding511.vector())).isGreaterThan(0.99);
     }
 
     @Test

--- a/langchain4j-embeddings-e5-small-v2-q/src/test/java/dev/langchain4j/model/embedding/E5_SMALL_V2_Q_EmbeddingModelTest.java
+++ b/langchain4j-embeddings-e5-small-v2-q/src/test/java/dev/langchain4j/model/embedding/E5_SMALL_V2_Q_EmbeddingModelTest.java
@@ -2,12 +2,13 @@ package dev.langchain4j.model.embedding;
 
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.store.embedding.RelevanceScore;
+import dev.langchain4j.store.embedding.Similarity;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static dev.langchain4j.internal.Utils.repeat;
+import static dev.langchain4j.model.embedding.internal.VectorUtils.magnitudeOf;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.data.Percentage.withPercentage;
 
 class E5_SMALL_V2_Q_EmbeddingModelTest {
@@ -56,14 +57,32 @@ class E5_SMALL_V2_Q_EmbeddingModelTest {
 
     @Test
     @Disabled("Temporary disabling. This test should run only when this or used (e.g. langchain4j-embeddings) module(s) change")
-    void should_fail_to_embed_511_token_long_text() {
+    void should_embed_text_longer_than_510_tokens_by_splitting_and_averaging_embeddings_of_splits() {
 
         EmbeddingModel model = new E5_SMALL_V2_Q_EmbeddingModel();
 
         String oneToken = "hello ";
 
-        assertThatThrownBy(() -> model.embed(repeat(oneToken, 511)))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Cannot embed text longer than 510 tokens. The following text is 511 tokens long: hello hello");
+        Embedding embedding510 = model.embed(repeat(oneToken, 510));
+        assertThat(embedding510.vector()).hasSize(384);
+
+        Embedding embedding520 = model.embed(repeat(oneToken, 520));
+        assertThat(embedding520.vector()).hasSize(384);
+
+        assertThat(Similarity.cosine(embedding510.vector(), embedding520.vector())).isGreaterThan(0.99);
+    }
+
+    @Test
+    @Disabled("Temporary disabling. This test should run only when this or used (e.g. langchain4j-embeddings) module(s) change")
+    void should_produce_normalized_vectors() {
+
+        EmbeddingModel model = new E5_SMALL_V2_Q_EmbeddingModel();
+
+        String oneToken = "hello ";
+
+        assertThat(magnitudeOf(model.embed(oneToken)))
+                .isCloseTo(1, withPercentage(0.01));
+        assertThat(magnitudeOf(model.embed(repeat(oneToken, 999))))
+                .isCloseTo(1, withPercentage(0.01));
     }
 }

--- a/langchain4j-embeddings-e5-small-v2/src/test/java/dev/langchain4j/model/embedding/E5_SMALL_V2_EmbeddingModelTest.java
+++ b/langchain4j-embeddings-e5-small-v2/src/test/java/dev/langchain4j/model/embedding/E5_SMALL_V2_EmbeddingModelTest.java
@@ -66,10 +66,10 @@ class E5_SMALL_V2_EmbeddingModelTest {
         Embedding embedding510 = model.embed(repeat(oneToken, 510));
         assertThat(embedding510.vector()).hasSize(384);
 
-        Embedding embedding520 = model.embed(repeat(oneToken, 520));
-        assertThat(embedding520.vector()).hasSize(384);
+        Embedding embedding511 = model.embed(repeat(oneToken, 511));
+        assertThat(embedding511.vector()).hasSize(384);
 
-        assertThat(Similarity.cosine(embedding510.vector(), embedding520.vector())).isGreaterThan(0.99);
+        assertThat(Similarity.cosine(embedding510.vector(), embedding511.vector())).isGreaterThan(0.99);
     }
 
     @Test

--- a/langchain4j-embeddings-e5-small-v2/src/test/java/dev/langchain4j/model/embedding/E5_SMALL_V2_EmbeddingModelTest.java
+++ b/langchain4j-embeddings-e5-small-v2/src/test/java/dev/langchain4j/model/embedding/E5_SMALL_V2_EmbeddingModelTest.java
@@ -2,12 +2,13 @@ package dev.langchain4j.model.embedding;
 
 import dev.langchain4j.data.embedding.Embedding;
 import dev.langchain4j.store.embedding.RelevanceScore;
+import dev.langchain4j.store.embedding.Similarity;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static dev.langchain4j.internal.Utils.repeat;
+import static dev.langchain4j.model.embedding.internal.VectorUtils.magnitudeOf;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.data.Percentage.withPercentage;
 
 class E5_SMALL_V2_EmbeddingModelTest {
@@ -56,14 +57,32 @@ class E5_SMALL_V2_EmbeddingModelTest {
 
     @Test
     @Disabled("Temporary disabling. This test should run only when this or used (e.g. langchain4j-embeddings) module(s) change")
-    void should_fail_to_embed_511_token_long_text() {
+    void should_embed_text_longer_than_510_tokens_by_splitting_and_averaging_embeddings_of_splits() {
 
         EmbeddingModel model = new E5_SMALL_V2_EmbeddingModel();
 
         String oneToken = "hello ";
 
-        assertThatThrownBy(() -> model.embed(repeat(oneToken, 511)))
-                .isExactlyInstanceOf(IllegalArgumentException.class)
-                .hasMessageStartingWith("Cannot embed text longer than 510 tokens. The following text is 511 tokens long: hello hello");
+        Embedding embedding510 = model.embed(repeat(oneToken, 510));
+        assertThat(embedding510.vector()).hasSize(384);
+
+        Embedding embedding520 = model.embed(repeat(oneToken, 520));
+        assertThat(embedding520.vector()).hasSize(384);
+
+        assertThat(Similarity.cosine(embedding510.vector(), embedding520.vector())).isGreaterThan(0.99);
+    }
+
+    @Test
+    @Disabled("Temporary disabling. This test should run only when this or used (e.g. langchain4j-embeddings) module(s) change")
+    void should_produce_normalized_vectors() {
+
+        EmbeddingModel model = new E5_SMALL_V2_EmbeddingModel();
+
+        String oneToken = "hello ";
+
+        assertThat(magnitudeOf(model.embed(oneToken)))
+                .isCloseTo(1, withPercentage(0.01));
+        assertThat(magnitudeOf(model.embed(repeat(oneToken, 999))))
+                .isCloseTo(1, withPercentage(0.01));
     }
 }

--- a/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/OnnxBertBiEncoder.java
+++ b/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/OnnxBertBiEncoder.java
@@ -18,7 +18,9 @@ import java.util.Map;
 import static ai.onnxruntime.OnnxTensor.createTensor;
 import static dev.langchain4j.internal.Exceptions.illegalArgument;
 import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+import static java.lang.Math.min;
 import static java.nio.LongBuffer.wrap;
+import static java.util.stream.Collectors.toList;
 
 public class OnnxBertBiEncoder {
 
@@ -43,37 +45,58 @@ public class OnnxBertBiEncoder {
     }
 
     public float[] embed(String text) {
-        int tokenCount = tokenizer.estimateTokenCountInText(text);
-        if (tokenCount > MAX_SEQUENCE_LENGTH) {
-            throw illegalArgument("Cannot embed text longer than %s tokens. " +
-                    "The following text is %s tokens long: %s", MAX_SEQUENCE_LENGTH, tokenCount, text);
+
+        List<String> wordPieces = tokenizer.tokenize(text);
+        List<List<String>> partitions = partition(wordPieces, MAX_SEQUENCE_LENGTH);
+
+        List<float[]> embeddings = new ArrayList<>();
+        for (List<String> partition : partitions) {
+            long[] tokens = toTokens(partition);
+            try (Result result = encode(tokens)) {
+                float[] embedding = toEmbedding(result);
+                embeddings.add(embedding);
+            } catch (OrtException e) {
+                throw new RuntimeException(e);
+            }
         }
-        try (Result result = encode(text)) {
-            return toEmbedding(result);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+
+        List<Integer> weights = partitions.stream()
+                .map(List::size)
+                .collect(toList());
+
+        return normalize(weightedAverage(embeddings, weights));
     }
 
-    private Result encode(String text) throws OrtException {
+    private static List<List<String>> partition(List<String> wordPieces, int partitionSize) {
+        List<List<String>> partitions = new ArrayList<>();
+        for (int from = 0; from < wordPieces.size(); from += partitionSize) {
+            int to = min(wordPieces.size(), from + partitionSize);
+            List<String> partition = wordPieces.subList(from, to);
+            partitions.add(partition);
+        }
+        return partitions;
+    }
 
-        List<String> stringTokens = new ArrayList<>();
-        stringTokens.add(CLS);
-        stringTokens.addAll(tokenizer.tokenize(text));
-        stringTokens.add(SEP);
+    private long[] toTokens(List<String> wordPieces) {
+        List<String> wrapped = new ArrayList<>();
+        wrapped.add(CLS);
+        wrapped.addAll(wordPieces);
+        wrapped.add(SEP);
 
-        // TODO reusable buffers
-        long[] tokens = stringTokens.stream()
+        return wrapped.stream()
                 .mapToLong(tokenizer::tokenId)
                 .toArray();
+    }
 
-        long[] attentionMasks = new long[stringTokens.size()];
-        for (int i = 0; i < stringTokens.size(); i++) {
+    private Result encode(long[] tokens) throws OrtException {
+
+        long[] attentionMasks = new long[tokens.length];
+        for (int i = 0; i < tokens.length; i++) {
             attentionMasks[i] = 1L;
         }
 
-        long[] tokenTypeIds = new long[stringTokens.size()];
-        for (int i = 0; i < stringTokens.size(); i++) {
+        long[] tokenTypeIds = new long[tokens.length];
+        for (int i = 0; i < tokens.length; i++) {
             tokenTypeIds[i] = 0L;
         }
 
@@ -93,28 +116,9 @@ public class OnnxBertBiEncoder {
         }
     }
 
-    private byte[] loadModel(InputStream modelInputStream) {
-        try (
-                InputStream inputStream = modelInputStream;
-                ByteArrayOutputStream buffer = new ByteArrayOutputStream()
-        ) {
-            int nRead;
-            byte[] data = new byte[1024];
-
-            while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
-                buffer.write(data, 0, nRead);
-            }
-
-            buffer.flush();
-            return buffer.toByteArray();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     private float[] toEmbedding(Result result) throws OrtException {
         float[][] vectors = ((float[][][]) result.get(0).getValue())[0];
-        return normalize(pool(vectors));
+        return pool(vectors);
     }
 
     private float[] pool(float[][] vectors) {
@@ -152,6 +156,32 @@ public class OnnxBertBiEncoder {
         return averagedVector;
     }
 
+    private float[] weightedAverage(List<float[]> embeddings, List<Integer> weights) {
+        if (embeddings.size() == 1) {
+            return embeddings.get(0);
+        }
+
+        int dimensions = embeddings.get(0).length;
+
+        float[] averagedEmbedding = new float[dimensions];
+        int totalWeight = 0;
+
+        for (int i = 0; i < embeddings.size(); i++) {
+            int weight = weights.get(i);
+            totalWeight += weight;
+
+            for (int j = 0; j < dimensions; j++) {
+                averagedEmbedding[j] += embeddings.get(i)[j] * weight;
+            }
+        }
+
+        for (int j = 0; j < dimensions; j++) {
+            averagedEmbedding[j] /= totalWeight;
+        }
+
+        return averagedEmbedding;
+    }
+
     private static float[] normalize(float[] vector) {
 
         float sumSquare = 0;
@@ -170,5 +200,24 @@ public class OnnxBertBiEncoder {
 
     int countTokens(String text) {
         return tokenizer.tokenize(text).size();
+    }
+
+    private byte[] loadModel(InputStream modelInputStream) {
+        try (
+                InputStream inputStream = modelInputStream;
+                ByteArrayOutputStream buffer = new ByteArrayOutputStream()
+        ) {
+            int nRead;
+            byte[] data = new byte[1024];
+
+            while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
+                buffer.write(data, 0, nRead);
+            }
+
+            buffer.flush();
+            return buffer.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/OnnxBertBiEncoder.java
+++ b/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/OnnxBertBiEncoder.java
@@ -78,14 +78,16 @@ public class OnnxBertBiEncoder {
     }
 
     private long[] toTokens(List<String> wordPieces) {
-        List<String> wrapped = new ArrayList<>();
-        wrapped.add(CLS);
-        wrapped.addAll(wordPieces);
-        wrapped.add(SEP);
+        long[] tokens = new long[wordPieces.size() + 2];
 
-        return wrapped.stream()
-                .mapToLong(tokenizer::tokenId)
-                .toArray();
+        int i = 0;
+        tokens[i++] = tokenizer.tokenId(CLS);
+        for (String wordPiece : wordPieces) {
+            tokens[i++] = tokenizer.tokenId(wordPiece);
+        }
+        tokens[i] = tokenizer.tokenId(SEP);
+
+        return tokens;
     }
 
     private Result encode(long[] tokens) throws OrtException {

--- a/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/internal/VectorUtils.java
+++ b/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/internal/VectorUtils.java
@@ -1,0 +1,18 @@
+package dev.langchain4j.model.embedding.internal;
+
+import dev.langchain4j.data.embedding.Embedding;
+
+public class VectorUtils {
+
+    public static float magnitudeOf(Embedding embedding) {
+        return magnitudeOf(embedding.vector());
+    }
+
+    public static float magnitudeOf(float[] vector) {
+        float sumOfSquares = 0.0f;
+        for (float v : vector) {
+            sumOfSquares += v * v;
+        }
+        return (float) Math.sqrt(sumOfSquares);
+    }
+}


### PR DESCRIPTION
If the text is longer than 510 tokens, it is automatically partitioned into parts <= 510 tokens long. These partitions are embedded independently and then weighted (by the number of tokens in each partition) average embedding is calculated.

Related to https://github.com/langchain4j/langchain4j/pull/119