### PR TITLE
Using TCCL to load the model instead of relying on the current abstract classloader.

### DIFF
--- a/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/AbstractInProcessEmbeddingModel.java
+++ b/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/AbstractInProcessEmbeddingModel.java
@@ -17,8 +17,8 @@ import static java.nio.file.Files.newInputStream;
 public abstract class AbstractInProcessEmbeddingModel implements EmbeddingModel, TokenCountEstimator {
 
     protected static OnnxBertBiEncoder loadFromJar(String modelFileName, String tokenizerFileName, PoolingMode poolingMode) {
-        InputStream model = AbstractInProcessEmbeddingModel.class.getResourceAsStream("/" + modelFileName);
-        InputStream tokenizer = AbstractInProcessEmbeddingModel.class.getResourceAsStream("/" + tokenizerFileName);
+        InputStream model = Thread.currentThread().getContextClassLoader().getResourceAsStream(modelFileName);
+        InputStream tokenizer = Thread.currentThread().getContextClassLoader().getResourceAsStream(tokenizerFileName);
         return new OnnxBertBiEncoder(model, tokenizer, poolingMode);
     }
 


### PR DESCRIPTION
If you don't have a flat classpath but a hierarchy of classloaders you might want to use the TCCL to provide access to the model.