### PR TITLE
Parallelize the embedding process

### DIFF
--- a/langchain4j-embeddings-all-minilm-l6-v2-q/src/main/java/dev/langchain4j/model/embedding/AllMiniLmL6V2QuantizedEmbeddingModel.java
+++ b/langchain4j-embeddings-all-minilm-l6-v2-q/src/main/java/dev/langchain4j/model/embedding/AllMiniLmL6V2QuantizedEmbeddingModel.java
@@ -1,5 +1,10 @@
 package dev.langchain4j.model.embedding;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 /**
  * Quantized SentenceTransformers all-MiniLM-L6-v2 embedding model that runs within your Java application's process.
  * <p>
@@ -21,9 +26,33 @@ public class AllMiniLmL6V2QuantizedEmbeddingModel extends AbstractInProcessEmbed
             PoolingMode.MEAN
     );
 
+    private final Executor executor;
+
+    /**
+     * Creates an instance of an {@code AllMiniLmL6V2QuantizedEmbeddingModel}.
+     * Uses a fixed thread pool with the number of threads equal to the number of available processors.
+     */
+    public AllMiniLmL6V2QuantizedEmbeddingModel() {
+        this(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
+    }
+
+    /**
+     * Creates an instance of an {@code AllMiniLmL6V2QuantizedEmbeddingModel}.
+     *
+     * @param executor The executor to use to parallelize the embedding process.
+     */
+    public AllMiniLmL6V2QuantizedEmbeddingModel(Executor executor) {
+        this.executor = ensureNotNull(executor, "executor");
+    }
+
     @Override
     protected OnnxBertBiEncoder model() {
         return MODEL;
+    }
+
+    @Override
+    protected Executor executor() {
+        return executor;
     }
 
     @Override

--- a/langchain4j-embeddings-all-minilm-l6-v2/src/main/java/dev/langchain4j/model/embedding/AllMiniLmL6V2EmbeddingModel.java
+++ b/langchain4j-embeddings-all-minilm-l6-v2/src/main/java/dev/langchain4j/model/embedding/AllMiniLmL6V2EmbeddingModel.java
@@ -1,5 +1,10 @@
 package dev.langchain4j.model.embedding;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 /**
  * SentenceTransformers all-MiniLM-L6-v2 embedding model that runs within your Java application's process.
  * <p>
@@ -21,9 +26,33 @@ public class AllMiniLmL6V2EmbeddingModel extends AbstractInProcessEmbeddingModel
             PoolingMode.MEAN
     );
 
+    private final Executor executor;
+
+    /**
+     * Creates an instance of an {@code AllMiniLmL6V2EmbeddingModel}.
+     * Uses a fixed thread pool with the number of threads equal to the number of available processors.
+     */
+    public AllMiniLmL6V2EmbeddingModel() {
+        this(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
+    }
+
+    /**
+     * Creates an instance of an {@code AllMiniLmL6V2EmbeddingModel}.
+     *
+     * @param executor The executor to use to parallelize the embedding process.
+     */
+    public AllMiniLmL6V2EmbeddingModel(Executor executor) {
+        this.executor = ensureNotNull(executor, "executor");
+    }
+
     @Override
     protected OnnxBertBiEncoder model() {
         return MODEL;
+    }
+
+    @Override
+    protected Executor executor() {
+        return executor;
     }
 
     @Override

--- a/langchain4j-embeddings-bge-small-en-q/src/main/java/dev/langchain4j/model/embedding/BgeSmallEnQuantizedEmbeddingModel.java
+++ b/langchain4j-embeddings-bge-small-en-q/src/main/java/dev/langchain4j/model/embedding/BgeSmallEnQuantizedEmbeddingModel.java
@@ -1,5 +1,10 @@
 package dev.langchain4j.model.embedding;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 /**
  * Quantized BAAI bge-small-en embedding model that runs within your Java application's process.
  * <p>
@@ -20,6 +25,30 @@ public class BgeSmallEnQuantizedEmbeddingModel extends AbstractInProcessEmbeddin
             "tokenizer.json",
             PoolingMode.CLS
     );
+
+    private final Executor executor;
+
+    /**
+     * Creates an instance of an {@code BgeSmallEnQuantizedEmbeddingModel}.
+     * Uses a fixed thread pool with the number of threads equal to the number of available processors.
+     */
+    public BgeSmallEnQuantizedEmbeddingModel() {
+        this(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
+    }
+
+    /**
+     * Creates an instance of an {@code BgeSmallEnQuantizedEmbeddingModel}.
+     *
+     * @param executor The executor to use to parallelize the embedding process.
+     */
+    public BgeSmallEnQuantizedEmbeddingModel(Executor executor) {
+        this.executor = ensureNotNull(executor, "executor");
+    }
+
+    @Override
+    protected Executor executor() {
+        return executor;
+    }
 
     @Override
     protected OnnxBertBiEncoder model() {

--- a/langchain4j-embeddings-bge-small-en-v15-q/src/main/java/dev/langchain4j/model/embedding/bge/small/en/v15/BgeSmallEnV15QuantizedEmbeddingModel.java
+++ b/langchain4j-embeddings-bge-small-en-v15-q/src/main/java/dev/langchain4j/model/embedding/bge/small/en/v15/BgeSmallEnV15QuantizedEmbeddingModel.java
@@ -4,6 +4,11 @@ import dev.langchain4j.model.embedding.AbstractInProcessEmbeddingModel;
 import dev.langchain4j.model.embedding.OnnxBertBiEncoder;
 import dev.langchain4j.model.embedding.PoolingMode;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 /**
  * Quantized BAAI bge-small-en-v1.5 embedding model that runs within your Java application's process.
  * <p>
@@ -25,9 +30,33 @@ public class BgeSmallEnV15QuantizedEmbeddingModel extends AbstractInProcessEmbed
             PoolingMode.CLS
     );
 
+    private final Executor executor;
+
+    /**
+     * Creates an instance of an {@code BgeSmallEnV15QuantizedEmbeddingModel}.
+     * Uses a fixed thread pool with the number of threads equal to the number of available processors.
+     */
+    public BgeSmallEnV15QuantizedEmbeddingModel() {
+        this(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
+    }
+
+    /**
+     * Creates an instance of an {@code BgeSmallEnV15QuantizedEmbeddingModel}.
+     *
+     * @param executor The executor to use to parallelize the embedding process.
+     */
+    public BgeSmallEnV15QuantizedEmbeddingModel(Executor executor) {
+        this.executor = ensureNotNull(executor, "executor");
+    }
+
     @Override
     protected OnnxBertBiEncoder model() {
         return MODEL;
+    }
+
+    @Override
+    protected Executor executor() {
+        return executor;
     }
 
     @Override

--- a/langchain4j-embeddings-bge-small-en-v15/src/main/java/dev/langchain4j/model/embedding/bge/small/en/v15/BgeSmallEnV15EmbeddingModel.java
+++ b/langchain4j-embeddings-bge-small-en-v15/src/main/java/dev/langchain4j/model/embedding/bge/small/en/v15/BgeSmallEnV15EmbeddingModel.java
@@ -4,6 +4,11 @@ import dev.langchain4j.model.embedding.AbstractInProcessEmbeddingModel;
 import dev.langchain4j.model.embedding.OnnxBertBiEncoder;
 import dev.langchain4j.model.embedding.PoolingMode;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 /**
  * BAAI bge-small-en-v1.5 embedding model that runs within your Java application's process.
  * <p>
@@ -25,9 +30,33 @@ public class BgeSmallEnV15EmbeddingModel extends AbstractInProcessEmbeddingModel
             PoolingMode.CLS
     );
 
+    private final Executor executor;
+
+    /**
+     * Creates an instance of an {@code BgeSmallEnV15EmbeddingModel}.
+     * Uses a fixed thread pool with the number of threads equal to the number of available processors.
+     */
+    public BgeSmallEnV15EmbeddingModel() {
+        this(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
+    }
+
+    /**
+     * Creates an instance of an {@code BgeSmallEnV15EmbeddingModel}.
+     *
+     * @param executor The executor to use to parallelize the embedding process.
+     */
+    public BgeSmallEnV15EmbeddingModel(Executor executor) {
+        this.executor = ensureNotNull(executor, "executor");
+    }
+
     @Override
     protected OnnxBertBiEncoder model() {
         return MODEL;
+    }
+
+    @Override
+    protected Executor executor() {
+        return executor;
     }
 
     @Override

--- a/langchain4j-embeddings-bge-small-en/src/main/java/dev/langchain4j/model/embedding/BgeSmallEnEmbeddingModel.java
+++ b/langchain4j-embeddings-bge-small-en/src/main/java/dev/langchain4j/model/embedding/BgeSmallEnEmbeddingModel.java
@@ -1,5 +1,10 @@
 package dev.langchain4j.model.embedding;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 /**
  * BAAI bge-small-en embedding model that runs within your Java application's process.
  * <p>
@@ -21,9 +26,33 @@ public class BgeSmallEnEmbeddingModel extends AbstractInProcessEmbeddingModel {
             PoolingMode.CLS
     );
 
+    private final Executor executor;
+
+    /**
+     * Creates an instance of an {@code BgeSmallEnEmbeddingModel}.
+     * Uses a fixed thread pool with the number of threads equal to the number of available processors.
+     */
+    public BgeSmallEnEmbeddingModel() {
+        this(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
+    }
+
+    /**
+     * Creates an instance of an {@code BgeSmallEnEmbeddingModel}.
+     *
+     * @param executor The executor to use to parallelize the embedding process.
+     */
+    public BgeSmallEnEmbeddingModel(Executor executor) {
+        this.executor = ensureNotNull(executor, "executor");
+    }
+
     @Override
     protected OnnxBertBiEncoder model() {
         return MODEL;
+    }
+
+    @Override
+    protected Executor executor() {
+        return executor;
     }
 
     @Override

--- a/langchain4j-embeddings-bge-small-zh-q/src/main/java/dev/langchain4j/model/embedding/BgeSmallZhQuantizedEmbeddingModel.java
+++ b/langchain4j-embeddings-bge-small-zh-q/src/main/java/dev/langchain4j/model/embedding/BgeSmallZhQuantizedEmbeddingModel.java
@@ -1,5 +1,10 @@
 package dev.langchain4j.model.embedding;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 /**
  * Quantized BAAI bge-small-zh embedding model that runs within your Java application's process.
  * <p>
@@ -21,9 +26,33 @@ public class BgeSmallZhQuantizedEmbeddingModel extends AbstractInProcessEmbeddin
             PoolingMode.CLS
     );
 
+    private final Executor executor;
+
+    /**
+     * Creates an instance of an {@code BgeSmallZhQuantizedEmbeddingModel}.
+     * Uses a fixed thread pool with the number of threads equal to the number of available processors.
+     */
+    public BgeSmallZhQuantizedEmbeddingModel() {
+        this(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
+    }
+
+    /**
+     * Creates an instance of an {@code BgeSmallZhQuantizedEmbeddingModel}.
+     *
+     * @param executor The executor to use to parallelize the embedding process.
+     */
+    public BgeSmallZhQuantizedEmbeddingModel(Executor executor) {
+        this.executor = ensureNotNull(executor, "executor");
+    }
+
     @Override
     protected OnnxBertBiEncoder model() {
         return MODEL;
+    }
+
+    @Override
+    protected Executor executor() {
+        return executor;
     }
 
     @Override

--- a/langchain4j-embeddings-bge-small-zh-v15-q/src/main/java/dev/langchain4j/model/embedding/bge/small/zh/v15/BgeSmallZhV15QuantizedEmbeddingModel.java
+++ b/langchain4j-embeddings-bge-small-zh-v15-q/src/main/java/dev/langchain4j/model/embedding/bge/small/zh/v15/BgeSmallZhV15QuantizedEmbeddingModel.java
@@ -4,6 +4,11 @@ import dev.langchain4j.model.embedding.AbstractInProcessEmbeddingModel;
 import dev.langchain4j.model.embedding.OnnxBertBiEncoder;
 import dev.langchain4j.model.embedding.PoolingMode;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 /**
  * Quantized BAAI bge-small-zh-v1.5 embedding model that runs within your Java application's process.
  * <p>
@@ -25,9 +30,33 @@ public class BgeSmallZhV15QuantizedEmbeddingModel extends AbstractInProcessEmbed
             PoolingMode.CLS
     );
 
+    private final Executor executor;
+
+    /**
+     * Creates an instance of an {@code BgeSmallZhV15QuantizedEmbeddingModel}.
+     * Uses a fixed thread pool with the number of threads equal to the number of available processors.
+     */
+    public BgeSmallZhV15QuantizedEmbeddingModel() {
+        this(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
+    }
+
+    /**
+     * Creates an instance of an {@code BgeSmallZhV15QuantizedEmbeddingModel}.
+     *
+     * @param executor The executor to use to parallelize the embedding process.
+     */
+    public BgeSmallZhV15QuantizedEmbeddingModel(Executor executor) {
+        this.executor = ensureNotNull(executor, "executor");
+    }
+
     @Override
     protected OnnxBertBiEncoder model() {
         return MODEL;
+    }
+
+    @Override
+    protected Executor executor() {
+        return executor;
     }
 
     @Override

--- a/langchain4j-embeddings-bge-small-zh-v15/src/main/java/dev/langchain4j/model/embedding/bge/small/zh/v15/BgeSmallZhV15EmbeddingModel.java
+++ b/langchain4j-embeddings-bge-small-zh-v15/src/main/java/dev/langchain4j/model/embedding/bge/small/zh/v15/BgeSmallZhV15EmbeddingModel.java
@@ -4,6 +4,11 @@ import dev.langchain4j.model.embedding.AbstractInProcessEmbeddingModel;
 import dev.langchain4j.model.embedding.OnnxBertBiEncoder;
 import dev.langchain4j.model.embedding.PoolingMode;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 /**
  * BAAI bge-small-zh-v1.5 embedding model that runs within your Java application's process.
  * <p>
@@ -25,9 +30,33 @@ public class BgeSmallZhV15EmbeddingModel extends AbstractInProcessEmbeddingModel
             PoolingMode.CLS
     );
 
+    private final Executor executor;
+
+    /**
+     * Creates an instance of an {@code BgeSmallZhV15EmbeddingModel}.
+     * Uses a fixed thread pool with the number of threads equal to the number of available processors.
+     */
+    public BgeSmallZhV15EmbeddingModel() {
+        this(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
+    }
+
+    /**
+     * Creates an instance of an {@code BgeSmallZhV15EmbeddingModel}.
+     *
+     * @param executor The executor to use to parallelize the embedding process.
+     */
+    public BgeSmallZhV15EmbeddingModel(Executor executor) {
+        this.executor = ensureNotNull(executor, "executor");
+    }
+
     @Override
     protected OnnxBertBiEncoder model() {
         return MODEL;
+    }
+
+    @Override
+    protected Executor executor() {
+        return executor;
     }
 
     @Override

--- a/langchain4j-embeddings-bge-small-zh/src/main/java/dev/langchain4j/model/embedding/BgeSmallZhEmbeddingModel.java
+++ b/langchain4j-embeddings-bge-small-zh/src/main/java/dev/langchain4j/model/embedding/BgeSmallZhEmbeddingModel.java
@@ -1,5 +1,10 @@
 package dev.langchain4j.model.embedding;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 /**
  * BAAI bge-small-zh embedding model that runs within your Java application's process.
  * <p>
@@ -21,9 +26,33 @@ public class BgeSmallZhEmbeddingModel extends AbstractInProcessEmbeddingModel {
             PoolingMode.CLS
     );
 
+    private final Executor executor;
+
+    /**
+     * Creates an instance of an {@code BgeSmallZhEmbeddingModel}.
+     * Uses a fixed thread pool with the number of threads equal to the number of available processors.
+     */
+    public BgeSmallZhEmbeddingModel() {
+        this(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
+    }
+
+    /**
+     * Creates an instance of an {@code BgeSmallZhEmbeddingModel}.
+     *
+     * @param executor The executor to use to parallelize the embedding process.
+     */
+    public BgeSmallZhEmbeddingModel(Executor executor) {
+        this.executor = ensureNotNull(executor, "executor");
+    }
+
     @Override
     protected OnnxBertBiEncoder model() {
         return MODEL;
+    }
+
+    @Override
+    protected Executor executor() {
+        return executor;
     }
 
     @Override

--- a/langchain4j-embeddings-e5-small-v2-q/src/main/java/dev/langchain4j/model/embedding/E5SmallV2QuantizedEmbeddingModel.java
+++ b/langchain4j-embeddings-e5-small-v2-q/src/main/java/dev/langchain4j/model/embedding/E5SmallV2QuantizedEmbeddingModel.java
@@ -1,5 +1,10 @@
 package dev.langchain4j.model.embedding;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 /**
  * Quantized Microsoft E5-small-v2 embedding model that runs within your Java application's process.
  * <p>
@@ -21,9 +26,33 @@ public class E5SmallV2QuantizedEmbeddingModel extends AbstractInProcessEmbedding
             PoolingMode.MEAN
     );
 
+    private final Executor executor;
+
+    /**
+     * Creates an instance of an {@code E5SmallV2QuantizedEmbeddingModel}.
+     * Uses a fixed thread pool with the number of threads equal to the number of available processors.
+     */
+    public E5SmallV2QuantizedEmbeddingModel() {
+        this(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
+    }
+
+    /**
+     * Creates an instance of an {@code E5SmallV2QuantizedEmbeddingModel}.
+     *
+     * @param executor The executor to use to parallelize the embedding process.
+     */
+    public E5SmallV2QuantizedEmbeddingModel(Executor executor) {
+        this.executor = ensureNotNull(executor, "executor");
+    }
+
     @Override
     protected OnnxBertBiEncoder model() {
         return MODEL;
+    }
+
+    @Override
+    protected Executor executor() {
+        return executor;
     }
 
     @Override

--- a/langchain4j-embeddings-e5-small-v2/src/main/java/dev/langchain4j/model/embedding/E5SmallV2EmbeddingModel.java
+++ b/langchain4j-embeddings-e5-small-v2/src/main/java/dev/langchain4j/model/embedding/E5SmallV2EmbeddingModel.java
@@ -1,5 +1,10 @@
 package dev.langchain4j.model.embedding;
 
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static dev.langchain4j.internal.ValidationUtils.ensureNotNull;
+
 /**
  * Microsoft E5-small-v2 embedding model that runs within your Java application's process.
  * <p>
@@ -21,9 +26,33 @@ public class E5SmallV2EmbeddingModel extends AbstractInProcessEmbeddingModel {
             PoolingMode.MEAN
     );
 
+    private final Executor executor;
+
+    /**
+     * Creates an instance of an {@code E5SmallV2EmbeddingModel}.
+     * Uses a fixed thread pool with the number of threads equal to the number of available processors.
+     */
+    public E5SmallV2EmbeddingModel() {
+        this(Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors()));
+    }
+
+    /**
+     * Creates an instance of an {@code E5SmallV2EmbeddingModel}.
+     *
+     * @param executor The executor to use to parallelize the embedding process.
+     */
+    public E5SmallV2EmbeddingModel(Executor executor) {
+        this.executor = ensureNotNull(executor, "executor");
+    }
+
     @Override
     protected OnnxBertBiEncoder model() {
         return MODEL;
+    }
+
+    @Override
+    protected Executor executor() {
+        return executor;
     }
 
     @Override


### PR DESCRIPTION
By default, all in-process embedding models will parallelize the embedding process.
Dy default, they will use `Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors())`.

There is an option to specify the `Executor` one wants to use instead of the default one.