### PR TITLE
#1596 Fix Dependency convergence issue + enable Maven Enforcer

### DIFF
--- a/langchain4j-embeddings/pom.xml
+++ b/langchain4j-embeddings/pom.xml
@@ -14,6 +14,10 @@
     <artifactId>langchain4j-embeddings</artifactId>
     <name>langchain4j-embeddings</name>
     <description>Common functionality for other langchain4j-embeddings-xxx modules</description>
+    
+    <properties>
+        <ai.djl.version>0.28.0</ai.djl.version>
+    </properties>
 
     <dependencies>
 
@@ -32,12 +36,16 @@
         <dependency>
             <groupId>ai.djl</groupId>
             <artifactId>api</artifactId>
-            <version>0.28.0</version>
+            <version>${ai.djl.version}</version>
             <exclusions>
                 <!-- due to CVE-2024-26308 and CVE-2024-25710-->
                 <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-compress</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -50,7 +58,7 @@
         <dependency>
             <groupId>ai.djl.huggingface</groupId>
             <artifactId>tokenizers</artifactId>
-            <version>0.28.0</version>
+            <version>${ai.djl.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>ai.djl</groupId>

--- a/langchain4j-embeddings/pom.xml
+++ b/langchain4j-embeddings/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>ai.djl.huggingface</groupId>
             <artifactId>tokenizers</artifactId>
-            <version>0.26.0</version>
+            <version>0.28.0</version>
         </dependency>
 
         <dependency>

--- a/langchain4j-embeddings/pom.xml
+++ b/langchain4j-embeddings/pom.xml
@@ -51,6 +51,12 @@
             <groupId>ai.djl.huggingface</groupId>
             <artifactId>tokenizers</artifactId>
             <version>0.28.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>ai.djl</groupId>
+                    <artifactId>api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,25 @@
                     </execution>
                 </executions>
             </plugin>
+            
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce</id>
+                        <configuration>
+                            <rules>
+                                <dependencyConvergence/>
+                            </rules>
+                        </configuration>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 
             <plugin>
                 <groupId>io.sundr</groupId>


### PR DESCRIPTION
Fixes https://github.com/langchain4j/langchain4j/issues/1596

This fixes the dependency convergence issues introduced in https://github.com/langchain4j/langchain4j-embeddings/pull/29/files. Since embedding manages a direct dependency on `ai.djl:api` to exclude `commons-compress`, I propose to add an exclusion of `ai.djl:api` from `ai.djl.huggingface` to avoid transitive dependencies issues.

Also added the enforcer to avoid this in the future.