### PR TITLE
#923  fix for  IndexOutOfBoundsException

### DIFF
--- a/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/OnnxBertBiEncoder.java
+++ b/langchain4j-embeddings/src/main/java/dev/langchain4j/model/embedding/onnx/OnnxBertBiEncoder.java
@@ -197,6 +197,10 @@ public class OnnxBertBiEncoder {
     }
 
     private float[] weightedAverage(List<float[]> embeddings, List<Integer> weights) {
+        if (embeddings.isEmpty()) {
+            throw new RuntimeException("Embeddings list cannot be empty");
+        }
+
         if (embeddings.size() == 1) {
             return embeddings.get(0);
         }


### PR DESCRIPTION
#923 - IndexOutOfBoundsException execption is fixed. Add validation to ensure embeddings list is not empty. changes:
-- added a check for an empty "embeddings"
-- Throws  RuntimeException if the embeddings list empty